### PR TITLE
Fix fragile version parsing and tighten Docker build hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.woodpecker
+*.md
+FUNDING.yml
+LICENSE
+update.sh

--- a/.woodpecker/.build.yaml
+++ b/.woodpecker/.build.yaml
@@ -7,9 +7,9 @@ steps:
       DOCKERHUB_PASS:
         from_secret: dockerhub_pass
     commands:
-      - NC_FULLVER=$( cat docker_ver )
-      - NC_MINORVER=$( cat docker_ver | cut -c 1-4 )
-      - NC_MAJORVER=$( cat docker_ver | cut -c 1-2 )
+      - NC_FULLVER=$(cat docker_ver)
+      - NC_MINORVER=$(cut -d. -f1,2 docker_ver)
+      - NC_MAJORVER=$(cut -d. -f1 docker_ver)
       - docker login docker.io -u fuzzymistborn -p $DOCKERHUB_PASS
       - docker login ghcr.io -u fuzzymistborn -p $GHCR_PASS
       - docker build -t fuzzymistborn/nextcloud-docker:latest -t fuzzymistborn/nextcloud-docker:$NC_FULLVER -t fuzzymistborn/nextcloud-docker:$NC_MINORVER -t fuzzymistborn/nextcloud-docker:$NC_MAJORVER -t ghcr.io/fuzzymistborn/nextcloud-docker:latest -t ghcr.io/fuzzymistborn/nextcloud-docker:$NC_FULLVER -t ghcr.io/fuzzymistborn/nextcloud-docker:$NC_MINORVER -t ghcr.io/fuzzymistborn/nextcloud-docker:$NC_MAJORVER .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM nextcloud:33.0.2
 
-RUN apt-get update && apt-get install -y procps smbclient libmagickcore-7.q16-10-extra && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends procps smbclient libmagickcore-7.q16-10-extra && rm -rf /var/lib/apt/lists/*

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker_version=$(skopeo inspect docker://docker.io/nextcloud:latest | grep -o 'NEXTCLOUD_VERSION=[0-9]*.[0-9]*.[0-9]*' | cut -c 19-30)
+docker_version=$(skopeo inspect docker://docker.io/nextcloud:latest | grep -o 'NEXTCLOUD_VERSION=[0-9]*\.[0-9]*\.[0-9]*' | cut -d= -f2)
 
 sed -i "/nextcloud/s/.*/FROM nextcloud:$docker_version/" Dockerfile
 


### PR DESCRIPTION
- update.sh: escape dots in regex and use `cut -d=` instead of hardcoded character offset so version extraction is robust for any version length
- .build.yaml: replace `cut -c 1-4` / `cut -c 1-2` with `cut -d. -f1,2` and `cut -d. -f1` so minor/major tags are correct for all version strings (e.g. 33.10.x would have produced "33.1" before)
- Dockerfile: add --no-install-recommends to reduce image size
- .dockerignore: exclude .git, CI config, docs, and scripts from build context to avoid sending ~162KB of unnecessary files to the daemon

